### PR TITLE
Have setlua.bat change links for luac as with lua

### DIFF
--- a/scripts/setlua.bat
+++ b/scripts/setlua.bat
@@ -56,6 +56,14 @@ IF not [%1]==[] (
       exit /b 1
     )
     Echo Installed lua%1.exe as lua.exe.
+
+    copy "%myownpath%luac%1.exe" "%myownpath%luac.exe" /B /Y > NUL
+    if not [!ERRORLEVEL!]==[0] (
+      echo Error: could not set the proper defaults. Do you have the right permissions?
+      exit /b 1
+    )
+    Echo Installed luac%1.exe as luac.exe.
+    
     REM create wrapper to LuaRocks
     ECHO @ECHO OFF                          >  "%~dp0luarocks.bat"
     ECHO SETLOCAL                           >> "%~dp0luarocks.bat"


### PR DESCRIPTION
The section of the `setlua` batch file that sets up new `lua` links,

`copy "%myownpath%lua%1.exe" "%myownpath%lua.exe" /B /Y > NUL`

Needs to set up new links for `luac` in parallel.  This pull request adds this code to the batch file.