### PR TITLE
Lua 5.5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /lua-5.2*
 /lua-5.3*
 /lua-5.4*
+/lua-5.5*
 /luarocks*
 /luawinmake*
 pax_global_header

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Multi-lua for Windows script
 ============================
 
 This batchfile will download, compile and configure a Lua installation with 
-versions 5.1, 5.2, 5.3, and 5.4 in parallel. Including the accompanying 
+versions 5.1, 5.2, 5.3, 5.4, and 5.5 in parallel. Including the accompanying 
 LuaRocks package manager for each version.
 
 Prerequisites
@@ -12,22 +12,32 @@ Make sure you have a compiler in your path;
  - MinGW in your system path (msys is not required)
  - for MS compilers, call `make.bat` from the Visual Studio (or Win SDK) commandshell
 
+Known issues
+============
+Luarocks doesn't work with the Lua 5.5 version. This project ships an older version
+of LuaRocks that is not compatible with Lua 5.5.
+
 Command
 =======
 
 ````
-Command:
-  MAKE [--clean] [--cleantarget] [--nocompat] [--51] [--52] [--53] [--54] [install [<location>]]
+Commandline script to download and install Lua 5.1, 5.2, 5.3, 5.4, and 5.5 with a LuaRocks installation for each.
+A 'setlua' script is made available to setup the environment for each version.
 
-  --51,--52,--53,--54: specify the versions to install, default is to install
-                       all versions. Applies only to installing, all versions will be
-                       build independent of this option.
-                       The first version listed will be set as the unversioned default.
+Usage:
+  MAKE [--clean] [--cleantarget] [--nocompat] [--51] [--52] [--53] [--54] [--55] [--ms|gcc] [install [<location>]]
+
+  --51,--52,--53,--54,--55: specify the versions to install, default is to install
+                            all versions. Applies only to installing, all versions will be
+                            build independent of this option.
+                            The first version listed will be set as the unversioned default.
   --clean            : removes downloaded and build artifacts, forcing a rebuild
   --cleantarget      : removes the target directory before installing. NOTE: the LuaRocks
                        installation will ALWAYS be removed, independent of this option!
   --nocompat         : build Lua without compatibility options. NOTE: this option
                        will not automatically clean. So clean when switching compatibility.
+  --ms|gcc           : force usage of either Microsoft (--ms) or gcc (--gcc) toolchain, if
+                       not provided it will be auto-detected.
   install <location> : will install (and build if necessary) the Lua versions. Default
                        location is 'C:\Lua'
 
@@ -63,9 +73,9 @@ What it does
 Usage
 =====
 
-Each Lua version will have its own executable; `lua51.exe`, `lua52.exe`, `lua53.exe`, and 
-`lua54.exe`. And for LuaRocks 4 batchfiles will be generated; `luarocks51.bat`,
-`luarocks52.bat`, `luarocks53.bat`, and `luarocks54.bat`.
+Each Lua version will have its own executable; `lua51.exe`, `lua52.exe`, `lua53.exe`, etc.
+And for LuaRocks multiple batchfiles will be generated; `luarocks51.bat`,
+`luarocks52.bat`, `luarocks53.bat`, etc.
 
 The luarocks batch files will be in the same directory as the lua executables, so
 only the Lua path has to be added to the system path.
@@ -84,6 +94,6 @@ location `c:\lua`).
 
 License
 =======
-Copyright 2015-2023, Thijs Schreijer.
+Copyright 2015-2025, Thijs Schreijer.
 MIT license for this project. Please note that other components are included
 which are covered by different licenses. See COPYING file for details.

--- a/lr244_cfg.lua_54
+++ b/lr244_cfg.lua_54
@@ -18,7 +18,7 @@ package.loaded["luarocks.cfg"] = cfg
 
 local util = require("luarocks.util")
 
-cfg.lua_version = _VERSION:match(" (5%.[1234])$") or "5.1"
+cfg.lua_version = _VERSION:match(" (5%.[12345])$") or "5.1"
 local version_suffix = cfg.lua_version:gsub("%.", "_")
 
 -- Load site-local global configurations

--- a/lr244_install.bat_54
+++ b/lr244_install.bat_54
@@ -250,7 +250,7 @@ local function check_flags()
 			die("Bundled Lua version is 5.1, cannot install "..vars.LUA_VERSION)
 		end
 	end
-	if not vars.LUA_VERSION:match("^5%.[1234]$") then
+	if not vars.LUA_VERSION:match("^5%.[12345]$") then
 		die("Bad argument: /LV must either be 5.1, 5.2, or 5.3")
 	end
   if USE_MSVC_MANUAL and USE_MINGW then
@@ -269,7 +269,7 @@ local function detect_lua_version(interpreter_path)
 	local full_version = handler:read("*a")
 	handler:close()
 
-	local version = full_version:match(" (5%.[1234])$")
+	local version = full_version:match(" (5%.[12345])$")
 	if not version then
 		return nil, "unknown interpreter version '" .. full_version .. "'"
 	end
@@ -281,7 +281,7 @@ local function look_for_interpreter(directory)
 	if lua_version_set then
 		names = {S"lua$LUA_VERSION.exe", S"lua$LUA_SHORTV.exe"}
 	else
-		names = {"lua5.4.exe", "lua54.exe", "lua5.3.exe", "lua53.exe", "lua5.2.exe", "lua52.exe", "lua5.1.exe", "lua51.exe"}
+		names = {"lua5.5.exe", "lua55.exe", "lua5.4.exe", "lua54.exe", "lua5.3.exe", "lua53.exe", "lua5.2.exe", "lua52.exe", "lua5.1.exe", "lua51.exe"}
 	end
 	table.insert(names, "lua.exe")
 	table.insert(names, "luajit.exe")
@@ -967,6 +967,9 @@ IF NOT "%LUA_PATH_5_3%"=="" (
 )
 IF NOT "%LUA_PATH_5_4%"=="" (
    SET "LUA_PATH_5_4=$LUADIR\?.lua;$LUADIR\?\init.lua;%LUA_PATH_5_4%"
+)
+IF NOT "%LUA_PATH_5_5%"=="" (
+   SET "LUA_PATH_5_5=$LUADIR\?.lua;$LUADIR\?\init.lua;%LUA_PATH_5_5%"
 )
 SET "PATH=$BINDIR;%PATH%"
 "$LUA_BINDIR\$LUA_INTERPRETER" "$BINDIR\]]..c..[[.lua" %*

--- a/make.bat
+++ b/make.bat
@@ -209,7 +209,9 @@ call scripts\download.bat %CLEAN%
 
 REM Temporary fix until upgrade to LuaRocks 3
 REM Fix LR 2.4.4 installer to support Lua 5.4
+REM rename luarocks\install.bat install.bat_old
 copy lr244_install.bat_54 luarocks\install.bat
+REM rename luarocks\src\luarocks\cfg.lua cfg.lua_old
 copy lr244_cfg.lua_54 luarocks\src\luarocks\cfg.lua
 
 REM Build the binaries

--- a/make.bat
+++ b/make.bat
@@ -80,6 +80,13 @@ if [%1]==[--54] (
   SHIFT
   GOTO HandleParameter
 )
+if [%1]==[--55] (
+  set ALLVERSIONS=
+  set VERSION55=%1
+  if [%DEFAULT%]==[] SET DEFAULT=55
+  SHIFT
+  GOTO HandleParameter
+)
 if [%1]==[install] (
   if [%2]==[] (
     SHIFT
@@ -97,16 +104,16 @@ echo.
 exit /b 1
 
 :Help
-echo Commandline script to download and install Lua 5.1, 5.2, 5.3, and 5.4 with a LuaRocks installation for each.
+echo Commandline script to download and install Lua 5.1, 5.2, 5.3, 5.4, and 5.5 with a LuaRocks installation for each.
 echo A 'setlua' script is made available to setup the environment for each version.
 echo.
 echo Usage:
-echo   MAKE [--clean] [--cleantarget] [--nocompat] [--51] [--52] [--53] [--54] [--ms^|gcc] [install [^<location^>]]
+echo   MAKE [--clean] [--cleantarget] [--nocompat] [--51] [--52] [--53] [--54] [--55] [--ms^|gcc] [install [^<location^>]]
 echo.
-echo   --51,--52,--53,--54: specify the versions to install, default is to install
-echo                        all versions. Applies only to installing, all versions will be
-echo                        build independent of this option.
-echo                        The first version listed will be set as the unversioned default.
+echo   --51,--52,--53,--54,--55: specify the versions to install, default is to install
+echo                             all versions. Applies only to installing, all versions will be
+echo                             build independent of this option.
+echo                             The first version listed will be set as the unversioned default.
 echo   --clean            : removes downloaded and build artifacts, forcing a rebuild
 echo   --cleantarget      : removes the target directory before installing. NOTE: the LuaRocks
 echo                        installation will ALWAYS be removed, independent of this option!
@@ -141,6 +148,7 @@ if [%ALLVERSIONS%]==[TRUE] (
   SET VERSION52=--52
   SET VERSION53=--53
   SET VERSION54=--54
+  SET VERSION55=--55
   SET DEFAULT=51
 )
 
@@ -298,6 +306,28 @@ if not [%VERSION54%]==[] (
   )
   copy "%LRTARGET%\lua\luarocks\site_config_5_4.lua2" "%LRTARGET%\lua\luarocks\site_config_5_4.lua"
   del "%LRTARGET%\lua\luarocks\site_config_5_4.lua2"
+  ENDLOCAL
+)
+
+if not [%VERSION55%]==[] (
+  REM Install 55
+  CD lua-5.5
+  CALL etc\winmake installv "%TARGET%"
+  CD ..\luarocks
+  CALL install /P "%LRTARGET%" /LV 5.5 /LUA "%TARGET%" /F /NOADMIN /Q /NOREG %LRCOMPILER%
+  COPY "%LRTARGET%\luarocks.bat" "%TARGET%\bin\luarocks55.bat"
+  CD ..
+  REM Now pulling a trick to insert a versioned path to the rocks directory into the
+  REM created 'site_config' file
+  SET INSERTLINE=site_config.LUAROCKS_ROCKS_SUBDIR=[[/lib/luarocks/rocks-5.5]]
+  SETLOCAL ENABLEDELAYEDEXPANSION
+  for /F "usebackq tokens=*" %%A in ("%LRTARGET%\lua\luarocks\site_config_5_5.lua") do (
+    echo %%A             >> "%LRTARGET%\lua\luarocks\site_config_5_5.lua2"
+    echo !INSERTLINE!    >> "%LRTARGET%\lua\luarocks\site_config_5_5.lua2"
+    SET INSERTLINE=--
+  )
+  copy "%LRTARGET%\lua\luarocks\site_config_5_5.lua2" "%LRTARGET%\lua\luarocks\site_config_5_5.lua"
+  del "%LRTARGET%\lua\luarocks\site_config_5_5.lua2"
   ENDLOCAL
 )
 

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -71,3 +71,14 @@ if exist lua-5.4\src\lua54.dll (
   CD ..
 )
 
+REM Build 55
+if exist lua-5.5\src\lua55.dll (
+  echo Skipping Lua 5.5 build, binaries already exist
+) else (
+  XCOPY /E/Y/Q "%MAKE%" "lua-5.5"
+  CD lua-5.5
+  CALL etc\winmake clean
+  CALL etc\winmake %TOOLCHAIN% %COMPAT%
+  CD ..
+)
+

--- a/scripts/download.bat
+++ b/scripts/download.bat
@@ -8,6 +8,7 @@ SET LUA51=lua-5.1.5
 SET LUA52=lua-5.2.4
 SET LUA53=lua-5.3.6
 SET LUA54=lua-5.4.8
+SET LUA55=lua-5.5.0
 SET LRVERSION=2.4.4
 
 REM Archive suffix to use for all downloads
@@ -35,6 +36,7 @@ echo start cleaning...
   RMDIR /S /Q "lua-5.2"
   RMDIR /S /Q "lua-5.3"
   RMDIR /S /Q "lua-5.4"
+  RMDIR /S /Q "lua-5.5"
   RMDIR /S /Q "luawinmake"
   RMDIR /S /Q "luarocks"
   echo done cleaning...
@@ -106,6 +108,15 @@ if not exist "%WORKDIR%lua-5.4\*.*" (
   xcopy "%LUA54%\*.*" "%WORKDIR%lua-5.4\" /E /Y /Q
 ) else (
   echo Skipping Lua 5.4 download, directory already exists
+)
+
+if not exist "%WORKDIR%lua-5.5\*.*" (
+  "%WORKDIR%tools\wget" --no-check-certificate --output-document=%LUA55%%DL_SUFFIX% %DL_PREFIX%%LUA55%%DL_SUFFIX%
+  "%WORKDIR%tools\7z" x -y %LUA55%.tar.gz >NUL
+  "%WORKDIR%tools\7z" x -y %LUA55%.tar >NUL
+  xcopy "%LUA55%\*.*" "%WORKDIR%lua-5.5\" /E /Y /Q
+) else (
+  echo Skipping Lua 5.5 download, directory already exists
 )
 
 REM The 'RMDIR' below might fail because of background processes like virus scanners etc having files open

--- a/scripts/setlua.bat
+++ b/scripts/setlua.bat
@@ -5,6 +5,7 @@ IF [%1]==[51] goto VersionOK
 IF [%1]==[52] goto VersionOK
 IF [%1]==[53] goto VersionOK
 IF [%1]==[54] goto VersionOK
+IF [%1]==[55] goto VersionOK
 IF [%1]==[--help] GOTO Help
 IF [%1]==[-help] GOTO Help
 IF [%1]==[help] GOTO Help
@@ -24,7 +25,7 @@ echo  %~n0 [version]
 echo.
 echo Options:
 echo  version   Lua-version to be set as the unversioned default.
-echo            Valid values; 51, 52, 53, or 54
+echo            Valid values; 51, 52, 53, 54, or 55
 echo.
 exit /b
 
@@ -91,6 +92,10 @@ REM setup Lua paths for 5.4, defaults will do, but we need to add the user-tree
 set LUA_CPATH_5_4=%appdata%\luarocks\lib\lua\5.4\?.dll;;
 set LUA_PATH_5_4=%appdata%\luarocks\share\lua\5.4\?.lua;%appdata%\luarocks\share\lua\5.4\?\init.lua;;
 
+REM setup Lua paths for 5.5, defaults will do, but we need to add the user-tree
+set LUA_CPATH_5_5=%appdata%\luarocks\lib\lua\5.5\?.dll;;
+set LUA_PATH_5_5=%appdata%\luarocks\share\lua\5.5\?.lua;%appdata%\luarocks\share\lua\5.5\?\init.lua;;
+
 
 REM cleanup the paths in case of duplicate entries
 REM to prevent a mess when calling this multiple times
@@ -103,6 +108,8 @@ for /f "tokens=*" %%i in ('lua %myownpath%clean_path.lua LUA_CPATH_5_3') do set 
 for /f "tokens=*" %%i in ('lua %myownpath%clean_path.lua LUA_PATH_5_3') do set LUA_PATH_5_3=%%i
 for /f "tokens=*" %%i in ('lua %myownpath%clean_path.lua LUA_CPATH_5_4') do set LUA_CPATH_5_4=%%i
 for /f "tokens=*" %%i in ('lua %myownpath%clean_path.lua LUA_PATH_5_4') do set LUA_PATH_5_4=%%i
+for /f "tokens=*" %%i in ('lua %myownpath%clean_path.lua LUA_CPATH_5_5') do set LUA_CPATH_5_5=%%i
+for /f "tokens=*" %%i in ('lua %myownpath%clean_path.lua LUA_PATH_5_5') do set LUA_PATH_5_5=%%i
 
 echo Paths have been set up for Lua binaries and modules. Active version;
 where lua


### PR DESCRIPTION
Adds Lua 5.5 support.

This fixes the installation, but LuaRocks remains non-functional
since it has illegal code (for Lua 5.5) in the old version used.